### PR TITLE
Make email prop optional

### DIFF
--- a/dist/react-mailto.js
+++ b/dist/react-mailto.js
@@ -104,12 +104,13 @@ var Mailto = function (_Component) {
 
 Mailto.propTypes = {
   children: _react.PropTypes.node.isRequired,
-  email: _react.PropTypes.string.isRequired,
+  email: _react.PropTypes.string,
   headers: _react.PropTypes.object,
   obfuscate: _react.PropTypes.bool
 };
 
 Mailto.defaultProps = {
+  email: '',
   obfuscate: false
 };
 

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ var Component = React.createClass({
 
 Property  | Type      | Argument     | Default   | Description
 ----------|-----------|--------------|-----------|------------
-email     | `string`  | `<required>` | `null`    | email address of the intended recipient.
+email     | `string`  | `<optional>` | ` `       | email address of the intended recipient.
 obfuscate | `boolean` | `<optional>` | `false`   | show the email address in the status bar.
 headers   | `object`  | `<optional>` | `null`    | any standard mail header fields. The most commonly-used of these are "subject", "cc", and "body" (which is not a true header field, but allows you to specify a short content message for the new email).
 

--- a/src/react-mailto.js
+++ b/src/react-mailto.js
@@ -50,12 +50,13 @@ class Mailto extends Component {
 
 Mailto.propTypes = {
   children: PropTypes.node.isRequired,
-  email: PropTypes.string.isRequired,
+  email: PropTypes.string,
   headers: PropTypes.object,
   obfuscate: PropTypes.bool
 };
 
 Mailto.defaultProps = {
+  email: '',
   obfuscate: false
 };
 

--- a/test/react-mailto.js
+++ b/test/react-mailto.js
@@ -23,4 +23,9 @@ describe('Mailto component', () => {
     const component = shallowOutput(Mailto, {email: 'j@sonbellamy.com', headers: { subject }});
     expect(component.props.href).to.equal(`mailto:j@sonbellamy.com?subject=${encodeURIComponent(subject)}`);
   });
+
+  it('should create a link without the email prop', () => {
+    const component = shallowOutput(Mailto, {});
+    expect(component.props.href).to.equal('mailto:');
+  });
 });


### PR DESCRIPTION
Actually we don't need to provide an E-Mail. And there might be use cases, where we don't want to provide one (e.g. Share with your friends Button). 
- [Example Link](mailto:)
- [Example Link with Subject](mailto:?subject=React%20rocks!)
